### PR TITLE
Track crashes

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,6 +78,8 @@ func JobHandler(collector Collector, jobs chan Job) {
 		outputs := make(chan golo.Output)
 
 		var lastRead time.Time
+		lastRead = time.Now() // cover cases where no outputs are set
+
 		go func() {
 			for o := range outputs {
 				lastRead = time.Now()


### PR DESCRIPTION
When schedules crash, currently, the job runner continues ticking along trying to make RPC calls and pushing to collectors. What we actually want is to cancel the test as soon as a crash occurs so we can, at the very least, schedule a new one.

This PR introduces a supervisor loop to determine whether a process is running or not. It does this by trying to send a SIGUSR1 to the process and breaking out when this fails.